### PR TITLE
Kramdown update

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,9 @@
 future: true
-markdown: rdiscount
+markdown: kramdown
+kramdown:
+  input: GFM
+  hard_wrap: false
+  parse_block_html: true
 pygments: true
 permalink: /posts/:title
 auto: false

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,6 @@ kramdown:
   input: GFM
   hard_wrap: false
   parse_block_html: true
-pygments: true
 permalink: /posts/:title
 auto: false
 exclude: [vendor]

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,11 +1,12 @@
 future: true
-markdown: rdiscount
-pygments: true
+markdown: kramdown
+kramdown:
+  input: GFM
+  hard_wrap: false
+  parse_block_html: true
 permalink: /posts/:title
 auto: false
 exclude: [vendor]
-rdiscount:
-  extensions: [smart]
 name: Hacker Within, University of California, Davis
 description: An initial blog and site for THW at UC Davis
 twitter: hackerwithin


### PR DESCRIPTION
Hi folks, I recently learned that GitHub is dropping support for rdiscount. Our current setup will look hideous as soon as that switch is flipped. This PR fixes it by relying on the GitHub-preferred kramdown.

See also:
https://github.com/holman/left/issues/43
https://github.com/github/pages-gem/issues/179
