### PR TITLE
Change category for previous posts to `previous`.

### DIFF
--- a/_posts/2016-01-14-web-scraping.markdown
+++ b/_posts/2016-01-14-web-scraping.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: Web Scraping
 author: Duncan Temple Lang
-categorya: previous
+category: previous
 tags: meeting web scraping
 ---
 

--- a/previous.md
+++ b/previous.md
@@ -9,7 +9,7 @@ Previous Topics
 ===============
 
 <ul class="listing">
-{% assign past_posts = (site.posts | where: "category" , "posts") %}
+{% assign past_posts = (site.posts | where: "category" , "previous") %}
 {% for post in past_posts %}
   <li>
     <span>{{ post.date | date: "%B %e, %Y" }}</span>


### PR DESCRIPTION
Fixes #15 

Alternatively, the posts that were categorized as "previous" could've been changed to "posts".
